### PR TITLE
Fix nodemon --watch command

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon --watch .env --watch ../frontend server.js"
+    "start": "nodemon --watch ../.env --watch server.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Fixing the `--watch` command to restart the application if `../.env` or `server.js` is changed.